### PR TITLE
Dev/bot enhance

### DIFF
--- a/python/tableturf_replica/bot.py
+++ b/python/tableturf_replica/bot.py
@@ -46,9 +46,8 @@ class BotSession:
   def finalize(self, params) -> None:
     pass
 
-  @staticmethod
-  def select_deck(params) -> Optional[List[int]]:
-    raise NotImplementedError()
+  def select_deck(self, params) -> Optional[List[int]]:
+    return None
 
 
 class BotEndpoint(Endpoint):
@@ -61,12 +60,13 @@ class BotEndpoint(Endpoint):
     return self._bot.get_info()
 
   def create_session(self, params):
-    session, deck = self._bot.create_session(params)
+    session = self._bot.create_session()
+    deck = session.select_deck(params)
     session_id = str(uuid4())
     self._sessions[session_id] = session
     return {
       'session': session_id,
-      'deck': deck
+      'deck': deck,
     }
 
   def session_initialize(self, params):
@@ -91,8 +91,7 @@ def bot(cls):
     def get_info(self) -> Dict[str, Any]:
       return cls.meta
 
-    def create_session(self, params) -> Tuple[BotSession, Optional[List[int]]]:
-      deck = InnerSession.select_deck(params)
-      return InnerSession(), deck
+    def create_session(self) -> BotSession:
+      return InnerSession()
 
   return InnerBot

--- a/python/tableturf_replica/bot.py
+++ b/python/tableturf_replica/bot.py
@@ -64,10 +64,10 @@ class BotEndpoint(Endpoint):
     deck = session.select_deck(params)
     session_id = str(uuid4())
     self._sessions[session_id] = session
-    return {
-      'session': session_id,
-      'deck': deck,
-    }
+    response = {'session': session_id}
+    if deck is not None:
+      response['deck'] = deck
+    return response
 
   def session_initialize(self, params):
     return self._sessions[params['session']].initialize(params['params'])

--- a/python/tableturf_replica/demo/dummy.py
+++ b/python/tableturf_replica/demo/dummy.py
@@ -7,7 +7,7 @@ class DummyBot:
     'name': 'PyDummy',
     'support': {
       'stages': [],
-      'anyDeck': True,
+      'decks': [],
     }
   }
 
@@ -16,11 +16,6 @@ class DummyBot:
       'action': 'discard',
       'hand': 0,
     }
-
-  @staticmethod
-  def select_deck(params):
-    print(params)
-    return params['deck']
 
 
 def main():

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -6,7 +6,7 @@ import { calibrateDeck } from "./core/Tableturf";
 const logger = getLogger("database");
 logger.setLevel("debug");
 
-const maxDeckCount = 10;
+const maxDeckCount = 8;
 
 const defaultData: IRootData = {
   playerName: "Player",

--- a/src/Schema.json
+++ b/src/Schema.json
@@ -73,8 +73,9 @@
                 },
                 "support": {
                     "properties": {
-                        "anyDeck": {
-                            "type": "boolean"
+                        "decks": {
+                            "items": {},
+                            "type": "array"
                         },
                         "stages": {
                             "items": {
@@ -84,7 +85,7 @@
                         }
                     },
                     "required": [
-                        "anyDeck",
+                        "decks",
                         "stages"
                     ],
                     "type": "object"
@@ -193,6 +194,9 @@
         },
         "ICard": {
             "properties": {
+                "category": {
+                    "type": "string"
+                },
                 "count": {
                     "properties": {
                         "area": {
@@ -233,6 +237,9 @@
                     ],
                     "type": "object"
                 },
+                "season": {
+                    "type": "number"
+                },
                 "size": {
                     "items": {
                         "type": "number"
@@ -247,11 +254,13 @@
                 }
             },
             "required": [
+                "category",
                 "count",
                 "id",
                 "name",
                 "rarity",
                 "render",
+                "season",
                 "size",
                 "values"
             ],

--- a/src/bots/DummyBot.ts
+++ b/src/bots/DummyBot.ts
@@ -6,7 +6,6 @@ import {
   IBotCreateSessionResponse,
 } from "../client/bot/Bot";
 import { v4 } from "uuid";
-import { StarterDeck } from "../Game";
 
 const logger = getLogger("dummy-bot");
 logger.setLevel("info");
@@ -15,8 +14,8 @@ export class DummyBot extends Bot {
   static readonly info: IBotInfo = {
     name: "Dummy",
     support: {
-      stages: [],
-      anyDeck: true,
+      stages: [2],
+      decks: [],
     },
   };
 
@@ -30,13 +29,8 @@ export class DummyBot extends Bot {
     return DummyBot.info;
   }
 
-  async createSession({
-    deck,
-  }: IBotCreateSessionRequest): Promise<IBotCreateSessionResponse> {
-    return {
-      session: new DummyBotSession(),
-      deck: deck || StarterDeck.slice(),
-    };
+  async createSession({}: IBotCreateSessionRequest): Promise<IBotCreateSessionResponse> {
+    return { session: new DummyBotSession() };
   }
 }
 

--- a/src/bots/DummyBot.ts
+++ b/src/bots/DummyBot.ts
@@ -29,7 +29,9 @@ export class DummyBot extends Bot {
     return DummyBot.info;
   }
 
-  async createSession({}: IBotCreateSessionRequest): Promise<IBotCreateSessionResponse> {
+  async createSession(
+    _: IBotCreateSessionRequest
+  ): Promise<IBotCreateSessionResponse> {
     return { session: new DummyBotSession() };
   }
 }

--- a/src/bots/RandomBot.ts
+++ b/src/bots/RandomBot.ts
@@ -30,7 +30,9 @@ export class RandomBot extends Bot {
     return RandomBot.info;
   }
 
-  async createSession({}: IBotCreateSessionRequest): Promise<IBotCreateSessionResponse> {
+  async createSession(
+    _: IBotCreateSessionRequest
+  ): Promise<IBotCreateSessionResponse> {
     return { session: new RandomBotSession() };
   }
 }

--- a/src/bots/RandomBot.ts
+++ b/src/bots/RandomBot.ts
@@ -6,7 +6,6 @@ import {
   IBotCreateSessionResponse,
 } from "../client/bot/Bot";
 import { v4 } from "uuid";
-import { StarterDeck } from "../Game";
 import { enumerateGameMoves } from "../core/Tableturf";
 
 const logger = getLogger("random-bot");
@@ -17,7 +16,7 @@ export class RandomBot extends Bot {
     name: "Random",
     support: {
       stages: [],
-      anyDeck: true,
+      decks: [],
     },
   };
 
@@ -31,13 +30,8 @@ export class RandomBot extends Bot {
     return RandomBot.info;
   }
 
-  async createSession({
-    deck,
-  }: IBotCreateSessionRequest): Promise<IBotCreateSessionResponse> {
-    return {
-      session: new RandomBotSession(),
-      deck: deck || StarterDeck.slice(),
-    };
+  async createSession({}: IBotCreateSessionRequest): Promise<IBotCreateSessionResponse> {
+    return { session: new RandomBotSession() };
   }
 }
 

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -199,6 +199,10 @@ export class Client {
     return this._prevState;
   }
 
+  get botInfo(): IBotInfo {
+    return null;
+  }
+
   protected getDefaultPlayerInfo(): TableturfPlayerInfo {
     return {
       name: DB.read().playerName,

--- a/src/client/bot/Client.ts
+++ b/src/client/bot/Client.ts
@@ -42,9 +42,13 @@ class BotClientImpl extends Client {
     super.stop();
   }
 
+  get botInfo(): IBotInfo {
+    return this.bot.info;
+  }
+
   protected getDefaultPlayerInfo(): TableturfPlayerInfo {
     return {
-      name: this.bot.info.name,
+      name: this.botInfo.name,
       deck: null,
     };
   }
@@ -81,7 +85,12 @@ class BotClientImpl extends Client {
         deck = requestDeck.slice();
       } else {
         if (!deck) {
-          deck = G.players[1 - this.playerId].deck.slice();
+          const decks = this.botInfo.support.decks;
+          if (!decks.length) {
+            deck = G.players[1 - this.playerId].deck.slice();
+          } else {
+            deck = decks[0].deck.slice();
+          }
         }
       }
       logger.log("create session ->", { session, deck });

--- a/src/client/bot/Client.ts
+++ b/src/client/bot/Client.ts
@@ -89,7 +89,9 @@ class BotClientImpl extends Client {
           if (!decks.length) {
             deck = G.players[1 - this.playerId].deck.slice();
           } else {
-            deck = decks[0].deck.slice();
+            let idx = Math.floor(Math.random() * decks.length);
+            idx = Math.min(decks.length - 1, Math.max(0, idx));
+            deck = decks[idx].deck.slice();
           }
         }
       }

--- a/src/client/bot/Typing.d.ts
+++ b/src/client/bot/Typing.d.ts
@@ -9,8 +9,8 @@ interface IBotInfo extends IBotInfoBrief {
   support: {
     // the stages supported by this bot, [] for any
     stages: number[];
-    // does this bot support any deck
-    anyDeck: boolean;
+    // the stages supported by this bot, [] for any
+    decks: IDeckData[];
   };
 }
 

--- a/src/ui/Theme.tsx
+++ b/src/ui/Theme.tsx
@@ -1,5 +1,8 @@
-import { Box, styled, createTheme } from "@mui/material";
+import { ReactNode } from "react";
+import { Box, styled, createTheme, Grid, Typography } from "@mui/material";
 import ToggleButton, { ToggleButtonTypeMap } from "@mui/material/ToggleButton";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 
 export const ResponsiveBox = styled(Box)(() => ({
   width: "max-content",
@@ -39,6 +42,78 @@ export const DarkButton = styled(BasicButton)(({ theme }) => ({
   },
 }));
 
+interface CollapsibleProps {
+  children: ReactNode;
+  open: boolean;
+  maxBodyHeight: number;
+  onClick?: () => void;
+}
+
+export function Collapsible({
+  children,
+  open,
+  maxBodyHeight,
+  onClick = () => {},
+}: CollapsibleProps) {
+  const color = open ? "text.primary" : "text.secondary";
+  const dt = 150;
+  return (
+    <Grid
+      className="collapsible"
+      container
+      spacing={2}
+      // flexDirection="row"
+      sx={{ width: "100%" }}
+    >
+      <Grid item xs={1}>
+        <Box
+          sx={{
+            width: 16,
+            height: "100%",
+            backgroundColor: color,
+            transition: `background-color ${dt}ms ease-out`,
+          }}
+        ></Box>
+      </Grid>
+      <Grid container item xs={11} spacing={2}>
+        <Grid item xs={12}>
+          <Typography
+            sx={{
+              fontSize: "0.8rem",
+              color,
+              cursor: "pointer",
+              "&:hover": {
+                textDecoration: "underline",
+              },
+              transition: `color ${dt}ms ease-out`,
+            }}
+            onClick={onClick}
+          >
+            Bot Settings
+            {open ? (
+              <ArrowDropUpIcon sx={{ fontSize: "1rem" }} />
+            ) : (
+              <ArrowDropDownIcon sx={{ fontSize: "1rem" }} />
+            )}
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          sx={{
+            overflow: "hidden",
+            maxHeight: open ? maxBodyHeight : 0,
+            pointerEvents: open ? "inherit" : "none",
+            transition: `all ${dt}ms ease-out`,
+          }}
+        >
+          {children}
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}
+
 const theme = createTheme({});
 
 export const Theme = createTheme({
@@ -74,13 +149,15 @@ export const Theme = createTheme({
     borderRadius: 16,
   },
   components: {
-    // MuiButton: {
-    //   styleOverrides: {
-    //     contained: {
-    //       backgroundColor: "#ffffffcc",
-    //     },
-    //   },
-    // },
+    MuiButton: {
+      styleOverrides: {
+        iconSizeMedium: {
+          "& > *:first-of-type": {
+            fontSize: "1rem",
+          },
+        },
+      },
+    },
     MuiPaper: {
       styleOverrides: {
         root: {

--- a/src/ui/activities/MatchActivity.tsx
+++ b/src/ui/activities/MatchActivity.tsx
@@ -125,9 +125,7 @@ class MatchActivity_0 extends Activity<MatchActivityProps> {
     if (support.stages.length) {
       this.props.client.send("updateState", { stage: support.stages[0] });
     }
-    await this.update({
-      botDeck: support.decks.length ? support.decks[0] : autoDeck,
-    });
+    await this.update({ botDeck: autoDeck });
   }
 
   private async handleUpdate(
@@ -249,9 +247,10 @@ class MatchActivity_0 extends Activity<MatchActivityProps> {
     const renderBotPanel = () => {
       const { botInfo } = this.props.client;
       const useCustomDeck = !botInfo.support.decks.length;
-      const decks = useCustomDeck
-        ? [autoDeck, ...DB.read().decks]
-        : botInfo.support.decks;
+      const decks = [
+        autoDeck,
+        ...(useCustomDeck ? DB.read().decks : botInfo.support.decks),
+      ];
       const deckMenuItems = decks.map(({ name, deck }, i) => (
         <MenuItem value={i} key={i} disabled={deck && !isValidDeck(deck)}>
           {name}
@@ -357,17 +356,19 @@ class MatchActivity_0 extends Activity<MatchActivityProps> {
                 selected={this.props.state.G.ready[this.props.player]}
                 disabled={this.isForbidden()}
                 onClick={() => {
-                  this.props.client.send("updatePlayerInfo", {
-                    deck: this.props.deck.deck,
-                  });
                   if (this.isVsBot()) {
-                    const players = this.props.state.G.players.slice();
-                    const botPlayer = 1 - this.props.player;
-                    players[botPlayer] = {
-                      ...players[botPlayer],
-                      deck: this.props.botDeck.deck,
-                    };
-                    this.props.client.send("updateState", { players });
+                    const players = this.props.state.G.players;
+                    console.assert(this.props.player == 0);
+                    this.props.client.send("updateState", {
+                      players: [
+                        { ...players[0], deck: this.props.deck.deck },
+                        { ...players[1], deck: this.props.botDeck.deck },
+                      ],
+                    });
+                  } else {
+                    this.props.client.send("updatePlayerInfo", {
+                      deck: this.props.deck.deck,
+                    });
                   }
                   this.props.client.send("toggleReady");
                 }}


### PR DESCRIPTION
allow bot to use custom deck
* bot can specify a group of valid deck through `bot.meta`
* player can choose a deck for a bot (among decks specified by that bot)
* deck can be chosen automatically if no option is specified